### PR TITLE
lsコマンドを作る4

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,10 +1,15 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
+
 MAX_CHUNK = 3
 TAB_SPACE = 8
 
-file_paths = Dir.entries('.')
+file_paths = Dir.entries('.').sort
+
+opt = OptionParser.new
+params = opt.getopts(ARGV, 'l')
 
 def except_hidden_file(file_paths)
   file_paths.reject { |element| element[0] == '.' }
@@ -21,7 +26,6 @@ def transpose_chunks(sliced_paths, num_rows)
   padded_slices.transpose.map(&:compact)
 end
 
-file_paths = file_paths.sort
 file_paths = except_hidden_file(file_paths)
 
 num_rows = (file_paths.size.to_f / MAX_CHUNK).ceil

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -9,7 +9,7 @@ TAB_SPACE = 8
 file_paths = Dir.entries('.').sort
 
 opt = OptionParser.new
-params = opt.getopts(ARGV, 'l')
+options = opt.getopts(ARGV, 'l')
 
 def except_hidden_file(file_paths)
   file_paths.reject { |element| element[0] == '.' }

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -110,10 +110,9 @@ if options['l']
       file_mode[:file_mode],
       file_mode[:nlink].rjust(max_string_modes[:nlink]),
       file_mode[:uid].ljust(max_string_modes[:uid]),
-      '',
-      file_mode[:gid].ljust(max_string_modes[:gid]),
-      file_mode[:size].rjust(max_string_modes[:size]),
-      file_mode[:mtime].ljust(max_string_modes[:mtime]),
+      file_mode[:gid].rjust(max_string_modes[:gid] + 1),
+      file_mode[:size].rjust(max_string_modes[:size] + 1),
+      file_mode[:mtime].rjust(max_string_modes[:mtime] + 1),
       file_mode[:file_path]
     ].join(' ')
     puts file_mode_print

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -60,9 +60,13 @@ end
 
 def apply_special_modes(special_modes, permissions)
   SPECIAL_MODE.each do |mode|
-    if special_modes == mode[:bit]
-      permissions[mode[:index]] == 'x' ? mode[:exec] : mode[:no_exec]
-    end
+    next unless special_modes == mode[:bit]
+
+    permissions[mode[:index]] = if permissions[mode[:index]] == 'x'
+                                  mode[:exec]
+                                else
+                                  mode[:no_exec]
+                                end
   end
   permissions
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -53,7 +53,8 @@ def convert_file_mode(file_stat)
   file_mode_octal = file_stat.mode.to_s(8).rjust(6, '0')
   file_mode = FILE_TYPE[file_stat.ftype].to_s
   file_permissions = file_mode_octal.slice(3..-1).chars.map { |char| FILE_MODE[char] }.join
-  # 特殊権限の確認
+  # 特殊権限の確認　特殊権限は8進数に変換されたファイルモードの3文字目に記載されている　そのためfile_mode_octal[2]を参照する
+  # 0は特殊権限なし、なので最初に弾く（apply_special_modesは1か2か4であるかを判別し、当てはめるため）
   file_permissions = apply_special_modes(file_mode_octal[2], file_permissions) if file_mode_octal[2] != '0'
   file_mode + file_permissions
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -54,12 +54,14 @@ def convert_file_mode(file_stat)
   file_mode = FILE_TYPE[file_stat.ftype].to_s
   file_permissions = file_mode_octal.slice(3..-1).chars.map { |char| FILE_MODE[char] }.join
   # 特殊権限の確認　特殊権限は8進数に変換されたファイルモードの3文字目に記載されている　そのためfile_mode_octal[2]を参照する
-  # 0は特殊権限なし、なので最初に弾く（apply_special_modesは1か2か4であるかを判別し、当てはめるため）
-  file_permissions = apply_special_modes(file_mode_octal[2], file_permissions) if file_mode_octal[2] != '0'
+  file_permissions = apply_special_modes(file_mode_octal[2], file_permissions)
   file_mode + file_permissions
 end
 
 def apply_special_modes(special_modes, permissions)
+  # 0は特殊権限なし、なので最初に弾く（特殊権限は1か2か4であるため）
+  return permissions if special_modes == '0'
+
   SPECIAL_MODE.each do |mode|
     next unless special_modes == mode[:bit]
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -43,6 +43,13 @@ def transpose_chunks(sliced_paths, num_rows)
   padded_slices.transpose.map(&:compact)
 end
 
+def convert_file_mode(file_stat)
+  file_mode_octal = file_stat.mode.to_s(8).rjust(6, '0')
+  file_mode = FILE_TYPE[file_stat.ftype].to_s
+  file_permissions = file_mode_octal.slice(3..-1).chars.map { |char| FILE_MODE[char] }.join
+  file_mode + file_permissions
+end
+
 file_paths = Dir.entries('.').sort
 
 opt = OptionParser.new
@@ -53,7 +60,7 @@ file_paths = except_hidden_file(file_paths)
 if options['l']
   file_paths.each do |file_path|
     file_stat = File.lstat(file_path)
-    file_mode_octal = file_stat.mode.to_s(8).rjust(6, '0')
+    file_mode = convert_file_mode(file_stat)
     nlink = file_stat.nlink
     uid = Etc.getpwuid(file_stat.uid).name
     gid = Etc.getgrgid(file_stat.gid).name

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -54,6 +54,13 @@ if options['l']
   file_paths.each do |file_path|
     file_stat = File.lstat(file_path)
     file_mode_octal = file_stat.mode.to_s(8).rjust(6, '0')
+    nlink = file_stat.nlink
+    uid = Etc.getpwuid(file_stat.uid).name
+    gid = Etc.getgrgid(file_stat.gid).name
+    size = file_stat.size
+    mtime = file_stat.mtime.strftime('%-m %d %H:%M')
+
+    puts "#{file_mode}\t#{nlink}\t#{uid}\t#{gid}\t#{size}\t#{mtime}\t#{file_path}"
   end
 else
   num_rows = (file_paths.size.to_f / MAX_CHUNK).ceil

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -51,7 +51,10 @@ options = opt.getopts(ARGV, 'l')
 file_paths = except_hidden_file(file_paths)
 
 if options['l']
-  p 'l'
+  file_paths.each do |file_path|
+    file_stat = File.lstat(file_path)
+    file_mode_octal = file_stat.mode.to_s(8).rjust(6, '0')
+  end
 else
   num_rows = (file_paths.size.to_f / MAX_CHUNK).ceil
   sliced_paths = chunk_file_paths(file_paths, num_rows)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -81,6 +81,16 @@ def format_file_mode(file_path)
   }
 end
 
+def calclate_max_string_modes(file_modes)
+  {
+    nlink: file_modes.map { |file_mode| file_mode[:nlink].size }.max,
+    uid: file_modes.map { |file_mode| file_mode[:uid].size }.max,
+    gid: file_modes.map { |file_mode| file_mode[:gid].size }.max,
+    size: file_modes.map { |file_mode| file_mode[:size].size }.max,
+    mtime: file_modes.map { |file_mode| file_mode[:mtime].size }.max
+  }
+end
+
 file_paths = Dir.entries('.').sort
 
 opt = OptionParser.new
@@ -104,6 +114,7 @@ if options['l']
     mtime = file_stat.mtime.strftime('%-m %d %H:%M')
 
     puts "#{file_mode}\t#{nlink}\t#{uid}\t#{gid}\t#{size}\t#{mtime}\t#{file_path}"
+  max_string_modes = calclate_max_string_modes(file_modes)
   end
 else
   num_rows = (file_paths.size.to_f / MAX_CHUNK).ceil

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,6 +6,27 @@ require 'optparse'
 MAX_CHUNK = 3
 TAB_SPACE = 8
 
+FILE_TYPE = {
+  'fifo' => 'p',
+  'characterSpecial' => 'c',
+  'directory' => 'd',
+  'blockSpecial' => 'b',
+  'file' => 'f',
+  'link' => 'l',
+  'socket' => 's'
+}.freeze
+
+FILE_MODE = {
+  '0' => '---',
+  '1' => '--x',
+  '2' => '-w-',
+  '3' => '-wx',
+  '4' => 'r--',
+  '5' => 'r-x',
+  '6' => 'rw-',
+  '7' => 'rwx'
+}.freeze
+
 def except_hidden_file(file_paths)
   file_paths.reject { |element| element[0] == '.' }
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'optparse'
+require 'etc'
 
 MAX_CHUNK = 3
 TAB_SPACE = 8

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,11 +6,6 @@ require 'optparse'
 MAX_CHUNK = 3
 TAB_SPACE = 8
 
-file_paths = Dir.entries('.').sort
-
-opt = OptionParser.new
-options = opt.getopts(ARGV, 'l')
-
 def except_hidden_file(file_paths)
   file_paths.reject { |element| element[0] == '.' }
 end
@@ -25,6 +20,11 @@ def transpose_chunks(sliced_paths, num_rows)
   padded_slices = sliced_paths.map { |slice| slice + [nil] * (num_rows - slice.length) }
   padded_slices.transpose.map(&:compact)
 end
+
+file_paths = Dir.entries('.').sort
+
+opt = OptionParser.new
+options = opt.getopts(ARGV, 'l')
 
 file_paths = except_hidden_file(file_paths)
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -58,6 +58,9 @@ options = opt.getopts(ARGV, 'l')
 file_paths = except_hidden_file(file_paths)
 
 if options['l']
+  total_blocks = file_paths.sum { |file_path| File.lstat(file_path).blocks }
+  puts "total #{total_blocks}"
+
   file_paths.each do |file_path|
     file_stat = File.lstat(file_path)
     file_mode = convert_file_mode(file_stat)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -71,11 +71,12 @@ def format_file_mode(file_path)
   file_stat = File.lstat(file_path)
   {
     file_mode: convert_file_mode(file_stat),
-    nlink: file_stat.nlink,
+    nlink: file_stat.nlink.to_s,
     uid: Etc.getpwuid(file_stat.uid).name,
     gid: Etc.getgrgid(file_stat.gid).name,
-    size: file_stat.size,
+    size: file_stat.size.to_s,
     mtime: file_stat.mtime.strftime('%-m %d %H:%M'),
+    file_path: file_path,
     blocks: file_stat.blocks
   }
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -104,17 +104,19 @@ if options['l']
 
   puts "total #{total_blocks}"
 
-  file_paths.each do |file_path|
-    file_stat = File.lstat(file_path)
-    file_mode = convert_file_mode(file_stat)
-    nlink = file_stat.nlink
-    uid = Etc.getpwuid(file_stat.uid).name
-    gid = Etc.getgrgid(file_stat.gid).name
-    size = file_stat.size
-    mtime = file_stat.mtime.strftime('%-m %d %H:%M')
-
-    puts "#{file_mode}\t#{nlink}\t#{uid}\t#{gid}\t#{size}\t#{mtime}\t#{file_path}"
   max_string_modes = calclate_max_string_modes(file_modes)
+  file_modes.each do |file_mode|
+    file_mode_print = [
+      file_mode[:file_mode],
+      file_mode[:nlink].rjust(max_string_modes[:nlink]),
+      file_mode[:uid].ljust(max_string_modes[:uid]),
+      '',
+      file_mode[:gid].ljust(max_string_modes[:gid]),
+      file_mode[:size].rjust(max_string_modes[:size]),
+      file_mode[:mtime].ljust(max_string_modes[:mtime]),
+      file_mode[:file_path]
+    ].join(' ')
+    puts file_mode_print
   end
 else
   num_rows = (file_paths.size.to_f / MAX_CHUNK).ceil

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -29,9 +29,9 @@ FILE_MODE = {
 }.freeze
 
 SPECIAL_MODE = [
-  { bit: '4', index: 2, exec: 's', no_exec: 'S' },
-  { bit: '2', index: 5, exec: 's', no_exec: 'S' },
-  { bit: '1', index: 8, exec: 't', no_exec: 'T' }
+  { bit: 4, index: 2, exec: 's', no_exec: 'S' },
+  { bit: 2, index: 5, exec: 's', no_exec: 'S' },
+  { bit: 1, index: 8, exec: 't', no_exec: 'T' }
 ].freeze
 
 def except_hidden_file(file_paths)
@@ -54,17 +54,18 @@ def convert_file_mode(file_stat)
   file_mode = FILE_TYPE[file_stat.ftype].to_s
   file_permissions = file_mode_octal.slice(3..-1).chars.map { |char| FILE_MODE[char] }.join
   # 特殊権限の確認　特殊権限は8進数に変換されたファイルモードの3文字目に記載されている　そのためfile_mode_octal[2]を参照する
-  file_permissions = apply_special_modes(file_mode_octal[2], file_permissions)
+  file_permissions = apply_special_modes(file_mode_octal[2].to_i, file_permissions)
   file_mode + file_permissions
 end
 
 def apply_special_modes(special_modes, permissions)
   # 0は特殊権限なし、なので最初に弾く（特殊権限は1か2か4であるため）
-  return permissions if special_modes == '0'
+  return permissions if special_modes.zero?
 
   SPECIAL_MODE.each do |mode|
-    next unless special_modes == mode[:bit]
+    next unless special_modes >= mode[:bit]
 
+    special_modes -= mode[:bit]
     permissions[mode[:index]] = if permissions[mode[:index]] == 'x'
                                   mode[:exec]
                                 else

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -28,6 +28,12 @@ FILE_MODE = {
   '7' => 'rwx'
 }.freeze
 
+SPECIAL_MODE = [
+  { bit: '4', index: 2, exec: 's', no_exec: 'S' },
+  { bit: '2', index: 5, exec: 's', no_exec: 'S' },
+  { bit: '1', index: 8, exec: 't', no_exec: 'T' }
+].freeze
+
 def except_hidden_file(file_paths)
   file_paths.reject { |element| element[0] == '.' }
 end
@@ -47,7 +53,18 @@ def convert_file_mode(file_stat)
   file_mode_octal = file_stat.mode.to_s(8).rjust(6, '0')
   file_mode = FILE_TYPE[file_stat.ftype].to_s
   file_permissions = file_mode_octal.slice(3..-1).chars.map { |char| FILE_MODE[char] }.join
+  # 特殊権限の確認
+  file_permissions = apply_special_modes(file_mode_octal[2], file_permissions) if file_mode_octal[2] != '0'
   file_mode + file_permissions
+end
+
+def apply_special_modes(special_modes, permissions)
+  SPECIAL_MODE.each do |mode|
+    if special_modes == mode[:bit]
+      permissions[mode[:index]] == 'x' ? mode[:exec] : mode[:no_exec]
+    end
+  end
+  permissions
 end
 
 file_paths = Dir.entries('.').sort

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -28,17 +28,21 @@ end
 
 file_paths = except_hidden_file(file_paths)
 
-num_rows = (file_paths.size.to_f / MAX_CHUNK).ceil
-sliced_paths = chunk_file_paths(file_paths, num_rows)
-shaped_file_paths_array = transpose_chunks(sliced_paths, num_rows)
+if options['l']
+  p 'l'
+else
+  num_rows = (file_paths.size.to_f / MAX_CHUNK).ceil
+  sliced_paths = chunk_file_paths(file_paths, num_rows)
+  shaped_file_paths_array = transpose_chunks(sliced_paths, num_rows)
 
-max_string_length = file_paths.map(&:length).max
+  max_string_length = file_paths.map(&:length).max
 
-shaped_file_paths_array.each do |array_element|
-  array_element.each do |element|
-    tab_count = ((max_string_length - element.length) / TAB_SPACE.to_f).ceil + 1 # タブの挿入する回数を計算
-    print element
-    print "\t" * tab_count
+  shaped_file_paths_array.each do |array_element|
+    array_element.each do |element|
+      tab_count = ((max_string_length - element.length) / TAB_SPACE.to_f).ceil + 1 # タブの挿入する回数を計算
+      print element
+      print "\t" * tab_count
+    end
+    puts
   end
-  puts
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -63,9 +63,8 @@ def apply_special_modes(special_modes, permissions)
   return permissions if special_modes.zero?
 
   SPECIAL_MODE.each do |mode|
-    next unless special_modes >= mode[:bit]
+    next unless (special_modes & mode[:bit]).positive?
 
-    special_modes -= mode[:bit]
     permissions[mode[:index]] = if permissions[mode[:index]] == 'x'
                                   mode[:exec]
                                 else

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -76,7 +76,7 @@ def format_file_mode(file_path)
     gid: Etc.getgrgid(file_stat.gid).name,
     size: file_stat.size.to_s,
     mtime: file_stat.mtime.strftime('%-m %d %H:%M'),
-    file_path: file_path,
+    file_path:,
     blocks: file_stat.blocks
   }
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -67,6 +67,19 @@ def apply_special_modes(special_modes, permissions)
   permissions
 end
 
+def format_file_mode(file_path)
+  file_stat = File.lstat(file_path)
+  {
+    file_mode: convert_file_mode(file_stat),
+    nlink: file_stat.nlink,
+    uid: Etc.getpwuid(file_stat.uid).name,
+    gid: Etc.getgrgid(file_stat.gid).name,
+    size: file_stat.size,
+    mtime: file_stat.mtime.strftime('%-m %d %H:%M'),
+    blocks: file_stat.blocks
+  }
+end
+
 file_paths = Dir.entries('.').sort
 
 opt = OptionParser.new
@@ -75,7 +88,9 @@ options = opt.getopts(ARGV, 'l')
 file_paths = except_hidden_file(file_paths)
 
 if options['l']
-  total_blocks = file_paths.sum { |file_path| File.lstat(file_path).blocks }
+  file_modes = file_paths.map { |file_path| format_file_mode(file_path) }
+  total_blocks = file_modes.map { |file_mode| file_mode[:blocks] }.sum
+
   puts "total #{total_blocks}"
 
   file_paths.each do |file_path|

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -12,7 +12,7 @@ FILE_TYPE = {
   'characterSpecial' => 'c',
   'directory' => 'd',
   'blockSpecial' => 'b',
-  'file' => 'f',
+  'file' => '-',
   'link' => 'l',
   'socket' => 's'
 }.freeze


### PR DESCRIPTION
## 関連ページ
https://bootcamp.fjord.jp/practices/224

## 最終更新
2024/06/20

## やりたいこと
- `-l`オプションの実装

## やったこと
- これまでの出力結果とは形が異なるため、`-l`オプションが指定されているときとそれ以外でif文で分岐をした
- ファイルのオプションを求め、hashの形で格納した
- ファイルの合計サイズを求め、`total xxx`の形で出力した
- 表示される文字の列を合わせるため、最大の文字列の長さを計算し、`ljust`,`rjust`で列を揃えた
- 特殊権限の存在確認をし、`apply_special_modes`で文字列に変更を加える処理を追加した
- 複数の特殊権限の付与に対応するため、権限が確認された場合に特殊権限の数値を減算する処理を実装した